### PR TITLE
Fix spelling of received in eBPF control code

### DIFF
--- a/agent/src/ebpf/user/ctrl.c
+++ b/agent/src/ebpf/user/ctrl.c
@@ -328,7 +328,7 @@ static int sockopt_msg_send(int clt_fd,
 	return ETR_OK;
 }
 
-/* free recieved msg */
+/* free received msg */
 static inline void sockopt_msg_free(struct tracer_sock_msg *msg)
 {
 	free(msg);

--- a/agent/src/ebpf/user/ctrl_tracer.c
+++ b/agent/src/ebpf/user/ctrl_tracer.c
@@ -337,8 +337,8 @@ static inline int msg_recv(int clt_fd, struct tracer_sock_msg_reply *reply_hdr,
 	res = readn(clt_fd, reply_hdr, len);
 	if (len != res) {
 		fprintf(stderr,
-			"[%s] socket msg header recv error -- %d/%d recieved\n",
-			__func__, res, len);
+                       "[%s] socket msg header recv error -- %d/%d received\n",
+                       __func__, res, len);
 		return -1;
 	}
 
@@ -360,8 +360,8 @@ static inline int msg_recv(int clt_fd, struct tracer_sock_msg_reply *reply_hdr,
 		res = readn(clt_fd, msg, reply_hdr->len);
 		if (res != reply_hdr->len) {
 			fprintf(stderr,
-				"[%s] socket msg body recv error -- %d/%d recieved\n",
-				__func__, res, (int)reply_hdr->len);
+                               "[%s] socket msg body recv error -- %d/%d received\n",
+                               __func__, res, (int)reply_hdr->len);
 			free(msg);
 			return -1;
 		}


### PR DESCRIPTION
## Summary
- fix typo "recieved" in eBPF ctrl comment
- fix typo "recieved" in ctrl_tracer error messages

## Testing
- `make -C agent/src/ebpf/test` *(fails: linker `/opt/rh/devtoolset-11/root/usr/bin/cc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959d2176e08321bc1c64b38e6b7207